### PR TITLE
Integral windup correction

### DIFF
--- a/src/FastPID.cpp
+++ b/src/FastPID.cpp
@@ -9,6 +9,7 @@ void FastPID::clear() {
   _last_sp = 0; 
   _last_out = 0;
   _sum = 0; 
+  _last_sum = 0;
   _last_err = 0;
   _cfg_err = false;
 } 

--- a/src/FastPID.h
+++ b/src/FastPID.h
@@ -32,6 +32,7 @@ public:
   ~FastPID();
 
   bool setCoefficients(float kp, float ki, float kd, float hz);
+  bool setBangBang(int32_t out, int32_t treshold);
   bool setOutputConfig(int bits, bool sign);
   bool setOutputRange(int16_t min, int16_t max);
   void clear();
@@ -51,7 +52,8 @@ private:
 
   // Configuration
   uint32_t _p, _i, _d;
-  int64_t _outmax, _outmin; 
+  int64_t _outmax, _outmin, _b; 
+  int32_t _btreshold;
   bool _cfg_err; 
   
   // State

--- a/src/FastPID.h
+++ b/src/FastPID.h
@@ -56,7 +56,7 @@ private:
   
   // State
   int16_t _last_sp, _last_out;
-  int64_t _sum;
+  int64_t _sum, _last_sum;
   int32_t _last_err;
 };
 


### PR DESCRIPTION
I included an anti integrator windup code. This avoid the windup issue with the integral part of the PID. The solution used is to stop integrator while the controller output is saturated. 